### PR TITLE
refactor: consolidated storage endpoint to https

### DIFF
--- a/config/dev/hsds/config.yml
+++ b/config/dev/hsds/config.yml
@@ -7,7 +7,7 @@ aws_secret_access_key: null # Replace with secret key for account
 aws_iam_role: null # For EC2 using IAM roles
 aws_region: null
 hsds_endpoint: https://data.biosimulations.dev # used for hateos links in response
-aws_s3_gateway: http://s3low.scality.uchc.edu # use endpoint for the region HSDS is running in, e.g. 'https://s3.amazonaws.com' for us-east-1
+aws_s3_gateway: https://s3low.scality.uchc.edu # use endpoint for the region HSDS is running in, e.g. 'https://s3.amazonaws.com' for us-east-1
 aws_dynamodb_gateway: null # use for dynamodb endpint, e.g. 'https://dynamodb.us-east-1.amazonaws.com',
 aws_lambda_gateway: null #  use lambda endpoint for region HSDS is running in.  See: https://docs.aws.amazon.com/general/latest/gr/lambda-service.html
 aws_dynamodb_users_table: null # set to table name if lambda is used to store usernames and passwords

--- a/config/prod/hsds/config.yml
+++ b/config/prod/hsds/config.yml
@@ -7,7 +7,7 @@ aws_secret_access_key: null # Replace with secret key for account
 aws_iam_role: null # For EC2 using IAM roles
 aws_region: null
 hsds_endpoint: https://data.biosimulations.org # used for hateos links in response
-aws_s3_gateway: http://s3low.scality.uchc.edu # use endpoint for the region HSDS is running in, e.g. 'https://s3.amazonaws.com' for us-east-1
+aws_s3_gateway: https://s3low.scality.uchc.edu # use endpoint for the region HSDS is running in, e.g. 'https://s3.amazonaws.com' for us-east-1
 aws_dynamodb_gateway: null # use for dynamodb endpint, e.g. 'https://dynamodb.us-east-1.amazonaws.com',
 aws_lambda_gateway: null #  use lambda endpoint for region HSDS is running in.  See: https://docs.aws.amazon.com/general/latest/gr/lambda-service.html
 aws_dynamodb_users_table: null # set to table name if lambda is used to store usernames and passwords


### PR DESCRIPTION
@bilalshaikh42 The storage endpoint is sometimes configured as `http` and sometimes as `https`. Is this intended?