### PR TITLE
refactor: updated configuration for temporary prod bucket

### DIFF
--- a/config/prod/combine-api/config.env
+++ b/config/prod/combine-api/config.env
@@ -3,7 +3,3 @@ RUN_COMBINE_ARCHIVE_TIMEOUT=30.0
 
 # bytes
 MAX_CONTENT_LENGTH=1.1e9
-
-# S3 prefix and maximum age for temporarily created COMBINE archives
-TEMP_COMBINE_ARCHIVE_S3_PREFIX=temp/createdCombineArchive/
-TEMP_COMBINE_ARCHIVE_MAX_AGE=1

--- a/config/prod/shared.env
+++ b/config/prod/shared.env
@@ -26,6 +26,7 @@ STORAGE_EXTERNAL_ENDPOINT=https://s3low.scality.uchc.edu
 STORAGE_PUBLIC_ENDPOINT=https://files.biosimulations.org/s3/
 STORAGE_BUCKET=biosimprod
 TEMP_STORAGE_BUCKET=biosim-temp-prod
+TEMP_STORAGE_MAX_AGE=1
 #STORAGE_ACCESS_KEY=
 #STORAGE_SECRET=
 

--- a/config/prod/shared.env
+++ b/config/prod/shared.env
@@ -22,7 +22,6 @@ NATS_HOST=nats://nats:4222
 
 # Storage buckets
 STORAGE_ENDPOINT=https://s3low.scality.uchc.edu
-STORAGE_EXTERNAL_ENDPOINT=https://s3low.scality.uchc.edu
 STORAGE_BUCKET=biosimprod
 TEMP_STORAGE_BUCKET=biosim-temp-prod
 TEMP_STORAGE_MAX_AGE=1

--- a/config/prod/shared.env
+++ b/config/prod/shared.env
@@ -23,7 +23,6 @@ NATS_HOST=nats://nats:4222
 # Storage buckets
 STORAGE_ENDPOINT=https://s3low.scality.uchc.edu
 STORAGE_EXTERNAL_ENDPOINT=https://s3low.scality.uchc.edu
-STORAGE_PUBLIC_ENDPOINT=https://files.biosimulations.org/s3/
 STORAGE_BUCKET=biosimprod
 TEMP_STORAGE_BUCKET=biosim-temp-prod
 TEMP_STORAGE_MAX_AGE=1


### PR DESCRIPTION
Will closes #48.

Should be merged with related secrets changes in biosimulations/secrets#11.

@bilalshaikh42 Any needed configuration changes can be collected here. This is intended to be merged until we're ready to deploy prod with the new Google buckets